### PR TITLE
Limit code snippets language scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 	"contributes": {
 		"snippets": [
 			{
+				"language": "html",
 				"path": "./.code-snippets"
 			}
 		]


### PR DESCRIPTION
## Description

Configure the VS Code extension to suggest the code snippets for the HTML language only. Prior to this change, the extension snippets were suggested in irrelevant languages, e.g. JavaScript, which created a lot of unnecessary noise.

## Testing Instructions

1. Checkout this PR's branch. 
2. `touch .vscode/launch.json`
3. Populate the `launch.json` with the following:
    <details><summary>Extension Development Configuration</summary>

    ````
    // A launch configuration that launches the extension inside a new window
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    {
      "version": "0.2.0",
      "configurations": [
        {
          "name": "Extension",
          "type": "extensionHost",
          "request": "launch",
          "args": [
            "--extensionDevelopmentPath=${workspaceFolder}"
          ]
        }
      ]
    }
    ````
    
    </details>
4. Open the extension directory with VS Code. 
5. Press <kbd>F5</kbd> to launch the Extension Development Host. 
6. Set the empty file's language to _JavaScript_. 
7. ✅ Verify this extension's snippets are not suggested. 
8. Set the empty file's language to _HTML_. 
9. ✅ Verify this extension's snippets are suggested.  